### PR TITLE
pass new height plus height change delta to `onHeightChanged`

### DIFF
--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -34,7 +34,7 @@ export default class AutoGrowingTextInput extends React.Component {
     if(nativeEvent.contentSize && this.props.autoGrowing) {
       newHeight = nativeEvent.contentSize.height;
       if(this.state.height !== newHeight && this.props.onHeightChanged) {
-        this.props.onHeightChanged();
+        this.props.onHeightChanged(newHeight, newHeight - this.state.height);
       }
     }
     this.setState({

--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -3,7 +3,8 @@ import React, {
   View,
   TextInput,
   StyleSheet,
-  PropTypes
+  PropTypes,
+  LayoutAnimation,
 } from 'react-native';
 
 export default class AutoGrowingTextInput extends React.Component {
@@ -37,6 +38,8 @@ export default class AutoGrowingTextInput extends React.Component {
         this.props.onHeightChanged(newHeight, this.state.height, newHeight - this.state.height);
       }
     }
+    
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     this.setState({
       height: newHeight
     });

--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -22,7 +22,7 @@ export default class AutoGrowingTextInput extends React.Component {
     return (
       <TextInput {...this.props} {...this.style}
         style={[this.props.style, {height: Math.min(this.props.maxHeight, Math.max(this.props.minHeight, this.state.height))}]}
-        multiline={true}
+        multiline={this.props.multiline === false ? false : true}
         onChange={(event) => this._onChangeNativeEvent(event.nativeEvent)}
         ref={(r) => { this._textInput = r; }}
       />

--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -34,7 +34,7 @@ export default class AutoGrowingTextInput extends React.Component {
     if(nativeEvent.contentSize && this.props.autoGrowing) {
       newHeight = nativeEvent.contentSize.height;
       if(this.state.height !== newHeight && this.props.onHeightChanged) {
-        this.props.onHeightChanged(newHeight, newHeight - this.state.height);
+        this.props.onHeightChanged(newHeight, this.state.height, newHeight - this.state.height);
       }
     }
     this.setState({

--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -33,7 +33,7 @@ export default class AutoGrowingTextInput extends React.Component {
     let newHeight = this.state.height;
     if(nativeEvent.contentSize && this.props.autoGrowing) {
       newHeight = nativeEvent.contentSize.height;
-      if(this.state.height !== newHeight && this.props.onHeightChanged) {
+      if(this.state.height !== newHeight && newHeight <= this.props.maxHeight && this.props.onHeightChanged) {
         this.props.onHeightChanged(newHeight, this.state.height, newHeight - this.state.height);
       }
     }

--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -39,7 +39,7 @@ export default class AutoGrowingTextInput extends React.Component {
       }
     }
     
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    LayoutAnimation.configureNext({...LayoutAnimation.Presets.easeInEaseOut, duration: 100});
     this.setState({
       height: newHeight
     });


### PR DESCRIPTION
minor enhancement to the last pull request. the height delta is actually what is most likely needed. I added this for u in react-native-gifted-messenger so its chat input can grow. I uses the height of the input to calculate animations for the the listview that contains the messages, i.e. move the listview above the textinput as it grows. 