### PR TITLE
import PropTypes from react

### DIFF
--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -1,11 +1,10 @@
 
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 
 import {
   View,
   TextInput,
   StyleSheet,
-  PropTypes,
   LayoutAnimation,
   NativeModules
 } from 'react-native';


### PR DESCRIPTION
From RN 0.26.0 imports have to be separated from react and react-native packages