### PR TITLE
Upgrade for react-native 0.48 & react 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ xcuserdata
 
 # Intellij
 *.iml
+
+# Node.js
+node_modules/

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "^16.0.0-alpha.12",
-    "react-native": "^0.47.1",
+    "react-native": "^0.48.2",
     "react-native-autogrow-textinput": "latest"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -6,8 +6,8 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "react": "16.0.0-alpha.6",
-    "react-native": "0.44.2",
+    "react": "^16.0.0-alpha.12",
+    "react-native": "^0.47.1",
     "react-native-autogrow-textinput": "latest"
   }
 }

--- a/ios/AutogrowTextInputManager.m
+++ b/ios/AutogrowTextInputManager.m
@@ -33,9 +33,10 @@ NSUInteger const kMaxDeferedGetScrollView = 15;
   UITextView *textView = [self valueForKey:@"_textView"];
   if (textView != nil && [self respondsToSelector:@selector(textViewDidChange:)])
   {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self textViewDidChange:textView];
-    });
+    // see https://github.com/wix/react-native-autogrow-textinput/issues/31#issuecomment-327802356
+    // dispatch_async(dispatch_get_main_queue(), ^{
+    //   [self textViewDidChange:textView];
+    // });
   }
 }
 @end

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "peerDependencies": {
     "react-native": ">=0.38.0",
     "react": ">=15.4.1"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -1,5 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import ReactNative, {View, TextInput, LayoutAnimation, Platform, NativeModules} from 'react-native';
+import PropTypes from 'prop-types';
 
 const ANDROID_PLATFORM = (Platform.OS === 'android');
 const IOS_PLATFORM = (Platform.OS === 'ios');
@@ -8,6 +9,16 @@ const DEFAULT_ANIM_DURATION = 100;
 const AutoGrowTextInputManager = NativeModules.AutoGrowTextInputManager;
 
 export default class AutoGrowingTextInput extends Component {
+  static defaultProps = {
+    autoGrowing: true,
+    minHeight: 35,
+    initialHeight: 35,
+    maxHeight: null,
+    animation: {animated: false, duration: DEFAULT_ANIM_DURATION},
+    disableScrollAndBounceIOS: false,
+    enableScrollToCaretIOS: false,
+  }
+
   constructor(props) {
     super(props);
 
@@ -192,13 +203,4 @@ AutoGrowingTextInput.propTypes = {
   animation: PropTypes.object,
   disableScrollAndBounceIOS: PropTypes.bool,
   enableScrollToCaretIOS: PropTypes.bool,
-};
-AutoGrowingTextInput.defaultProps = {
-  autoGrowing: true,
-  minHeight: 35,
-  initialHeight: 35,
-  maxHeight: null,
-  animation: {animated: false, duration: DEFAULT_ANIM_DURATION},
-  disableScrollAndBounceIOS: false,
-  enableScrollToCaretIOS: false,
 };


### PR DESCRIPTION
* Change from using `React.PropTypes` to [`prop-types`](https://github.com/facebook/prop-types) module (see https://facebook.github.io/react/warnings/dont-call-proptypes.html)
* Move `defaultProps` to a `static`
* Add `node_modules/` to `.gitignore`
* Update example to use react-native 0.48 & react 16 (will need a release as it installs & uses the latest release of this module from npm)
* Address #31, may need advice on this one