### PR TITLE
Added prop-types node module

### DIFF
--- a/src/AutoGrowingTextInput.js
+++ b/src/AutoGrowingTextInput.js
@@ -1,5 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import ReactNative, {View, TextInput, LayoutAnimation, Platform, NativeModules} from 'react-native';
+import PropTypes from 'prop-types';
 
 const ANDROID_PLATFORM = (Platform.OS === 'android');
 const IOS_PLATFORM = (Platform.OS === 'ios');


### PR DESCRIPTION
React as deprecated importing of PropTypes from react:

`import React, {Component, PropTypes} from "react";` 

They have created a separate node module prop-type for the same:

`import PropTypes from 'prop-types'`

In ReactNative >=0.49.0 it is throwing exception due to which app is not working

Can you please approve this merge request, so that in next release onwards we can get the fix for the same

Please let me know in case any discussion is needed