### PR TITLE
Update build tools and the appcompat-v7 library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
@@ -20,7 +20,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.0.0'
     compile 'com.facebook.react:react-native:+'
 
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
The upgrade of the appcompat-v7 library is necessary to use this react-native package with the newer build tools in order not to get an error like: `AAPT: error: resource android:attr/fontVariationSettings not found.`